### PR TITLE
Allow passing apd and msp values to the constructor.

### DIFF
--- a/easyCrystallography/Components/AtomicDisplacement.py
+++ b/easyCrystallography/Components/AtomicDisplacement.py
@@ -213,10 +213,10 @@ class AtomicDisplacement(BaseObj):
         if adp_class_name in _AVAILABLE_ISO_TYPES.keys():
             adp_class = _AVAILABLE_ISO_TYPES[adp_class_name]
             # enable passing ADP parameters to constructor
-            m = getattr(kwargs["adp_class"], adp_class_name)
-            kwargs[adp_class_name] = m
             if "adp_class" in kwargs.keys():
-               _ = kwargs.pop("adp_class")
+                m = getattr(kwargs["adp_class"], adp_class_name)
+                kwargs[adp_class_name] = m
+                _ = kwargs.pop("adp_class")
             adp = adp_class(**kwargs, interface=interface)
         else:
             raise AttributeError(f"{adp_class_name} is not a valid adp type")

--- a/easyCrystallography/Components/AtomicDisplacement.py
+++ b/easyCrystallography/Components/AtomicDisplacement.py
@@ -212,6 +212,9 @@ class AtomicDisplacement(BaseObj):
         adp_class_name = adp_type.raw_value
         if adp_class_name in _AVAILABLE_ISO_TYPES.keys():
             adp_class = _AVAILABLE_ISO_TYPES[adp_class_name]
+            # enable passing ADP parameters to constructor
+            m = getattr(kwargs["adp_class"], adp_class_name)
+            kwargs[adp_class_name] = m
             if "adp_class" in kwargs.keys():
                _ = kwargs.pop("adp_class")
             adp = adp_class(**kwargs, interface=interface)

--- a/easyCrystallography/Components/Susceptibility.py
+++ b/easyCrystallography/Components/Susceptibility.py
@@ -79,6 +79,7 @@ class Cani(MSPBase):
                  chi_22: Optional[Union[Parameter, float]] = None,
                  chi_23: Optional[Union[Parameter, float]] = None,
                  chi_33: Optional[Union[Parameter, float]] = None,
+                 msp_values: Optional[Type[MSPBase]] = None,
                  interface=None):
 
         super(Cani, self).__init__('Cani',
@@ -101,16 +102,27 @@ class Cani(MSPBase):
             self.chi_23 = chi_23
         if chi_33 is not None:
             self.chi_33 = chi_33
+        if msp_values is not None:
+            self.chi_11 = msp_values.chi_11
+            self.chi_12 = msp_values.chi_12
+            self.chi_13 = msp_values.chi_13
+            self.chi_22 = msp_values.chi_22
+            self.chi_23 = msp_values.chi_23
+            self.chi_33 = msp_values.chi_33
         self.interface = interface
 
 class Ciso(MSPBase):
     chi: ClassVar[Parameter]
 
-    def __init__(self, chi: Optional[Union[Parameter, float]] = None, interface: Optional[iF] = None):
+    def __init__(self, chi: Optional[Union[Parameter, float]] = None,
+                 msp_values: Optional[Type[MSPBase]] = None,
+                 interface: Optional[iF] = None):
         super(Ciso, self).__init__('Ciso',
                                    chi=Parameter('chi', **_ANIO_DETAILS['Ciso']))
         if chi is not None:
             self.chi = chi
+        if msp_values is not None:
+            self.chi = msp_values.chi
         self.interface = interface
 
 _AVAILABLE_ISO_TYPES = {
@@ -130,6 +142,8 @@ class MagneticSusceptibility(BaseObj):
         msp_class_name = msp_type.raw_value
         if msp_class_name in _AVAILABLE_ISO_TYPES.keys():
             msp_class = _AVAILABLE_ISO_TYPES[msp_class_name]
+            # enable passing chi values directly to constructor
+            kwargs['msp_values'] = kwargs['msp_class']
             if "msp_class" in kwargs:
                 _ = kwargs.pop("msp_class")
             msp = msp_class(**kwargs, interface=interface)

--- a/easyCrystallography/Components/Susceptibility.py
+++ b/easyCrystallography/Components/Susceptibility.py
@@ -142,9 +142,9 @@ class MagneticSusceptibility(BaseObj):
         msp_class_name = msp_type.raw_value
         if msp_class_name in _AVAILABLE_ISO_TYPES.keys():
             msp_class = _AVAILABLE_ISO_TYPES[msp_class_name]
-            # enable passing chi values directly to constructor
-            kwargs['msp_values'] = kwargs['msp_class']
             if "msp_class" in kwargs:
+                # enable passing chi values directly to constructor
+                kwargs['msp_values'] = kwargs['msp_class']
                 _ = kwargs.pop("msp_class")
             msp = msp_class(**kwargs, interface=interface)
         else:


### PR DESCRIPTION
This is an attempt to fix an issue when using the json->dict decoder from Core, the main class constructor would silently drop the passed MSP and ADP values. Now, the values are explicitly send to the appropriate class constructors, updating the attributes.

This should not affect any other aspect of functionality of these classes.
