### PR TITLE
Adp cif naming

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -3,6 +3,8 @@ name: CI using pip
 on: [push, pull_request]
 
 jobs:
+
+  # Job 1
   Code_Consistency:
     runs-on: ubuntu-latest
     steps:
@@ -14,9 +16,10 @@ jobs:
             echo "::notice::In project root run 'python.exe -m ruff . --fix' and commit changes to fix issues."
             : # exit 1
 
+  # Job 2
   Code_Testing:
     strategy:
-      max-parallel: 4
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -33,12 +36,12 @@ jobs:
 
     - name: Install dependencies
       run: pip install -e '.[dev]'
-    
+
     - name: Test with tox
       run: |
         pip install tox tox-gh-actions coverage
         tox
-  
+
     - name: Upload coverage
       uses: codecov/codecov-action@v4.0.1
       with:
@@ -49,6 +52,7 @@ jobs:
         OS: ${{ matrix.os }}
         PYTHON: ${{ matrix.python-version }}
 
+  # Job 3
   Package_Testing:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Suggestion to fix issues
         if: ${{ failure() }}
         run: |
-            echo "::notice::In project root run 'python.exe -m ruff . --fix' and commit changes to fix issues."
+            echo "::notice::In project root run 'python -m ruff check . --fix' and commit changes to fix issues."
             : # exit 1
 
   # Job 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,12 +115,12 @@ exclude = [
 [tool.ruff.format]
 quote-style = "single"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # allow asserts in test files
 "*test_*.py" = ["S101"]
 
 [tool.ruff.lint]
-ignore-init-module-imports = true
+#ignore-init-module-imports = true
 select = [
     # flake8 settings from existing CI setup
     "E9", "F63", "F7", "F82",

--- a/src/easycrystallography/Components/Site.py
+++ b/src/easycrystallography/Components/Site.py
@@ -74,8 +74,21 @@ class Site(BaseObj):
     ):
 
         b_iso_or_equiv = kwargs.get("b_iso_or_equiv", None)
+        u_iso_or_equiv = kwargs.get("u_iso_or_equiv", None)
+
+        if b_iso_or_equiv is not None and u_iso_or_equiv is not None:
+            raise AttributeError("Cannot set both Biso and Uiso")
+
+        if b_iso_or_equiv is None and u_iso_or_equiv is None:
+            adp = AtomicDisplacement("Uiso", Uiso=0)
+            kwargs["adp"] = adp
+
         if b_iso_or_equiv is not None:
             adp = AtomicDisplacement("Biso", Biso=b_iso_or_equiv)
+            kwargs["adp"] = adp
+
+        if u_iso_or_equiv is not None:
+            adp = AtomicDisplacement("Uiso", Uiso=u_iso_or_equiv)
             kwargs["adp"] = adp
 
         super(Site, self).__init__(
@@ -150,6 +163,22 @@ class Site(BaseObj):
     @property
     def z(self) -> Parameter:
         return self.fract_z
+
+    @property
+    def b_iso_or_equiv(self) -> Parameter:
+        if not hasattr(self, 'adp'):
+            return None
+        if not hasattr(self.adp, 'Biso'):
+            return None
+        return self.adp.Biso
+
+    @property
+    def u_iso_or_equiv(self) -> Parameter:
+        if not hasattr(self, 'adp'):
+            return None
+        if not hasattr(self.adp, 'Uiso'):
+            return None
+        return self.adp.Uiso
 
     @property
     def is_magnetic(self) -> bool:

--- a/src/easycrystallography/Components/Site.py
+++ b/src/easycrystallography/Components/Site.py
@@ -73,13 +73,14 @@ class Site(BaseObj):
         **kwargs,
     ):
 
+        adp = kwargs.get("adp", None)
         b_iso_or_equiv = kwargs.get("b_iso_or_equiv", None)
         u_iso_or_equiv = kwargs.get("u_iso_or_equiv", None)
 
         if b_iso_or_equiv is not None and u_iso_or_equiv is not None:
             raise AttributeError("Cannot set both Biso and Uiso")
 
-        if b_iso_or_equiv is None and u_iso_or_equiv is None:
+        if adp is None and b_iso_or_equiv is None and u_iso_or_equiv is None:
             adp = AtomicDisplacement("Uiso", Uiso=0)
             kwargs["adp"] = adp
 


### PR DESCRIPTION
* Add aliases for Uiso and Biso to follow the CIF naming convention
* Add default ADP (Uiso=0) if it is not defined when atom site object is created