### PR TITLE
unpin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,23 +23,23 @@ classifiers = [
 ]
 requires-python = '>=3.10,<3.14'
 dependencies = [
-  'asteval == 1.0.6',       # For evaluating mathematical expressions
-  'easyscience == 1.3.0',   # The base library of the EasyScience framework
-  'gemmi == 0.7.0',         # For handling CIF files
-  'numpy == 2.2.4',         # For numerical calculations
-  'periodictable == 2.0.2', # For atomic properties
-  'uncertainties == 3.2.2', # For error propagation
-  'versioningit == 3.1.2',  # For versioning
-  'xarray == 2025.1.2',     # For handling data arrays
+  'asteval',              # For evaluating mathematical expressions
+  'easyscience <= 1.3.0', # The base library of the EasyScience framework
+  'gemmi',                # For handling CIF files
+  'numpy',                # For numerical calculations
+  'periodictable',        # For atomic properties
+  'uncertainties',        # For error propagation
+  'versioningit',         # For versioning
+  'xarray',               # For handling data arrays
 ]
 
 [project.optional-dependencies]
 dev = [
-  'build == 1.2.2.post1',  # For building the package
-  'pytest == 8.3.5',       # For testing
-  'pytest-xdist == 3.6.1', # For parallel testing
-  'pytest-cov == 6.0.0',   # For coverage
-  'ruff == 0.11.0',        # For linting
+  'build',        # For building the package
+  'pytest',       # For testing
+  'pytest-xdist', # For parallel testing
+  'pytest-cov',   # For coverage
+  'ruff',         # For linting
 ]
 
 [project.urls]


### PR DESCRIPTION
We need to unpin dependencies for the libraries, so the installation can pull the most recent (updated) versions of dependencies.
We only put the upper limit on our modules (EasyScience) in order to avoid breaking while installing this version when future versions of EasyScience get a new, incompatible API.