### PR TITLE
New easycore support

### DIFF
--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -157,6 +157,8 @@ jobs:
           pytest --cov=src/easycrystallography tests --cov-branch --cov-report=xml:coverage-unit.xml
 
       - name: Upload coverage reports to Codecov
+        # only on ubuntu to avoid multiple uploads
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v5
         with:
           name: unit-tests-job

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-latest, macos-15-intel]
         python-version: ['3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
@@ -199,7 +199,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-latest, macos-15-intel]
         python-version: ['3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing.yaml
+++ b/.github/workflows/ci-testing.yaml
@@ -152,30 +152,20 @@ jobs:
         run: pip install '.[dev]'
 
       - name: Run Python tests and create coverage report
-        run:
-          pytest tests/ --cov=./ --cov-report=xml:coverage/coverage.xml
-          --junitxml=./coverage/junit.xml --color=yes -n auto
+        run: |
+          pip install pytest pytest-cov
+          pytest --cov=src/easycrystallography tests --cov-branch --cov-report=xml:coverage-unit.xml
 
-      #- name: Upload test results to Codecov
-      #  if: ${{ !cancelled() }}
-      #  uses: codecov/test-results-action@v1
-      #  with:
-      #    files: ./coverage/junit.xml
-      #    fail_ci_if_error: true  # optional (default = false)
-      #    name: Pytest results
-      #    token: ${{ secrets.CODECOV_TOKEN }}
-
-      #- name: Upload coverage report to Codecov
-      #  uses: codecov/codecov-action@v4
-      #  with:
-      #    files: ./coverage/coverage.xml
-      #    env_vars: OS,PYTHON
-      #    fail_ci_if_error: true  # optional (default = false)
-      #    name: Pytest coverage
-      #    token: ${{ secrets.CODECOV_TOKEN }}
-      #  env:
-      #    OS: ${{ matrix.os }}
-      #    PYTHON: ${{ matrix.python-version }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          name: unit-tests-job
+          flags: unittests
+          files: ./coverage-unit.xml
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: EasyScience/EasyCrystallography
 
       - name: Create Python package
         run: python -m build --wheel --outdir dist

--- a/MIGRATION_ANALYSIS.md
+++ b/MIGRATION_ANALYSIS.md
@@ -2,9 +2,14 @@
 
 ## Executive Summary
 
-This document contains the impact analysis for migrating EasyCrystallography from the old corelib architecture (`ObjBase`, `CollectionBase`) to the new architecture (`ModelBase`, `ModelCollection`, `CalculatorFactoryBase`).
+This document contains the impact analysis for migrating EasyCrystallography
+from the old corelib architecture (`ObjBase`, `CollectionBase`) to the new
+architecture (`ModelBase`, `ModelCollection`, `CalculatorFactoryBase`).
 
-**Note:** EasyCrystallography is a simpler case than EasyReflectometryLib as it does not have its own calculator implementations. The `interface` parameter exists on objects but is passed through for downstream applications (like EasyDiffraction) to use.
+**Note:** EasyCrystallography is a simpler case than EasyReflectometryLib as it
+does not have its own calculator implementations. The `interface` parameter
+exists on objects but is passed through for downstream applications (like
+EasyDiffraction) to use.
 
 ---
 
@@ -79,11 +84,13 @@ ModelCollection (corelib - new)
 
 ### Current Pattern
 
-Unlike EasyReflectometryLib, EasyCrystallography does **not** have its own calculator implementations. The `interface` parameter is:
+Unlike EasyReflectometryLib, EasyCrystallography does **not** have its own
+calculator implementations. The `interface` parameter is:
 
 1. **Accepted** by constructors on most classes (Lattice, Site, Phase, etc.)
 2. **Stored** on the object as `self.interface`
-3. **Used minimally** - only `Site.add_adp()` calls `self.interface.generate_bindings(self)` (line 205)
+3. **Used minimally** - only `Site.add_adp()` calls
+   `self.interface.generate_bindings(self)` (line 205)
 4. **Passed through** to downstream applications like EasyDiffraction
 
 ### Migration Approach
@@ -92,22 +99,23 @@ Since there's no CalculatorFactory in EasyCrystallography:
 
 1. **No PR2 equivalent needed** - No calculator refactoring required
 2. **Interface parameter** should be made optional with `None` default
-3. **generate_bindings calls** in `Site.add_adp()` should be made conditional or removed
+3. **generate_bindings calls** in `Site.add_adp()` should be made conditional or
+   removed
 4. The `interface` can remain as a passthrough for downstream compatibility
 
 ---
 
 ## 3. Breaking Changes Inventory
 
-| Component | Old API | New API | Breaking Change | Mitigation |
-|-----------|---------|---------|-----------------|------------|
-| All `ObjBase` classes | Inherits `ObjBase` | Inherits `ModelBase` via `BaseCore` | Constructor signature | Add compatibility `__init__` |
-| `name` property | Direct from `ObjBase` | Maps to `display_name` | Property access | Property wrapper in `BaseCore` |
-| `interface` property | Direct property | Keep for downstream compat | None | Keep as optional parameter |
-| `Atoms`, `Phases` | Inherits `CollectionBase` | Inherits `ModelCollection` via `BaseCollection` | Constructor signature | Add compatibility `__init__` |
-| Serialization | `as_dict()` custom patterns | `to_dict()` from SerializerBase | Method names | Alias methods |
-| Object creation | `name` parameter | `unique_name` + `display_name` | Parameter naming | Map in constructor |
-| Parameter access | `self.kwarg_name` magic | Explicit or via `_kwargs` | Attribute access | Custom `__getattr__` |
+| Component             | Old API                     | New API                                         | Breaking Change       | Mitigation                     |
+| --------------------- | --------------------------- | ----------------------------------------------- | --------------------- | ------------------------------ |
+| All `ObjBase` classes | Inherits `ObjBase`          | Inherits `ModelBase` via `BaseCore`             | Constructor signature | Add compatibility `__init__`   |
+| `name` property       | Direct from `ObjBase`       | Maps to `display_name`                          | Property access       | Property wrapper in `BaseCore` |
+| `interface` property  | Direct property             | Keep for downstream compat                      | None                  | Keep as optional parameter     |
+| `Atoms`, `Phases`     | Inherits `CollectionBase`   | Inherits `ModelCollection` via `BaseCollection` | Constructor signature | Add compatibility `__init__`   |
+| Serialization         | `as_dict()` custom patterns | `to_dict()` from SerializerBase                 | Method names          | Alias methods                  |
+| Object creation       | `name` parameter            | `unique_name` + `display_name`                  | Parameter naming      | Map in constructor             |
+| Parameter access      | `self.kwarg_name` magic     | Explicit or via `_kwargs`                       | Attribute access      | Custom `__getattr__`           |
 
 ---
 
@@ -115,26 +123,26 @@ Since there's no CalculatorFactory in EasyCrystallography:
 
 ### Core Files to Modify (PR1: Base Class Replacements)
 
-| File | Current Base | Target Base | Changes Required |
-|------|--------------|-------------|------------------|
-| `Components/Lattice.py` | `ObjBase` | `BaseCore` | Update import, change base class |
-| `Components/Site.py` | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes, handle interface |
-| `Components/AtomicDisplacement.py` | `ObjBase` | `BaseCore` | Update import, change base class |
-| `Components/SpaceGroup.py` | `ObjBase` | `BaseCore` | Update import, change base class |
-| `Components/Susceptibility.py` | `ObjBase` | `BaseCore` | Update import, change base class |
-| `Structures/Phase.py` | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes |
+| File                               | Current Base                | Target Base                  | Changes Required                                      |
+| ---------------------------------- | --------------------------- | ---------------------------- | ----------------------------------------------------- |
+| `Components/Lattice.py`            | `ObjBase`                   | `BaseCore`                   | Update import, change base class                      |
+| `Components/Site.py`               | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes, handle interface |
+| `Components/AtomicDisplacement.py` | `ObjBase`                   | `BaseCore`                   | Update import, change base class                      |
+| `Components/SpaceGroup.py`         | `ObjBase`                   | `BaseCore`                   | Update import, change base class                      |
+| `Components/Susceptibility.py`     | `ObjBase`                   | `BaseCore`                   | Update import, change base class                      |
+| `Structures/Phase.py`              | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes                   |
 
 ### New Files to Create
 
-| File | Purpose |
-|------|---------|
-| `Components/base_core.py` | Compatibility layer between `ModelBase` and legacy patterns |
-| `Components/base_collection.py` (or in same file) | Compatibility layer for collections |
+| File                                              | Purpose                                                     |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| `Components/base_core.py`                         | Compatibility layer between `ModelBase` and legacy patterns |
+| `Components/base_collection.py` (or in same file) | Compatibility layer for collections                         |
 
 ### Files with Minor Changes
 
-| File | Changes Required |
-|------|------------------|
+| File                     | Changes Required                  |
+| ------------------------ | --------------------------------- |
 | `Components/__init__.py` | Export new base classes if needed |
 | `Structures/__init__.py` | Export new base classes if needed |
 
@@ -145,6 +153,7 @@ Since there's no CalculatorFactory in EasyCrystallography:
 ### 5.1 Lattice (Components/Lattice.py)
 
 **Current:**
+
 ```python
 from easyscience import ObjBase as BaseObj
 
@@ -155,18 +164,20 @@ class Lattice(BaseObj):
 ```
 
 **Target:**
+
 ```python
 from easycrystallography.Components.base_core import BaseCore
 
 class Lattice(BaseCore):
     def __init__(self, ..., interface=None, ...):
-        super().__init__('lattice', interface=interface, 
+        super().__init__('lattice', interface=interface,
                          length_a=..., ...)
 ```
 
 ### 5.2 Site (Components/Site.py)
 
 **Current:**
+
 ```python
 from easyscience import ObjBase as BaseObj
 from easyscience.base_classes import CollectionBase
@@ -176,6 +187,7 @@ class Atoms(CollectionBase): ...
 ```
 
 **Target:**
+
 ```python
 from easycrystallography.Components.base_core import BaseCore
 from easycrystallography.Components.base_collection import BaseCollection
@@ -185,15 +197,19 @@ class Atoms(BaseCollection): ...
 ```
 
 **Special handling:**
-- `Site.add_adp()` has `self.interface.generate_bindings(self)` - make conditional
+
+- `Site.add_adp()` has `self.interface.generate_bindings(self)` - make
+  conditional
 
 ### 5.3 AtomicDisplacement (Components/AtomicDisplacement.py)
 
-**Classes to migrate:** `AdpBase`, `Anisotropic`, `Isotropic`, `AnisotropicBij`, `IsotropicB`, `AtomicDisplacement`
+**Classes to migrate:** `AdpBase`, `Anisotropic`, `Isotropic`, `AnisotropicBij`,
+`IsotropicB`, `AtomicDisplacement`
 
 ### 5.4 SpaceGroup (Components/SpaceGroup.py)
 
 **Current:**
+
 ```python
 from easyscience import ObjBase as BaseObj
 
@@ -210,6 +226,7 @@ class SpaceGroup(BaseObj):
 ### 5.6 Phase (Structures/Phase.py)
 
 **Current:**
+
 ```python
 from easyscience import ObjBase as BaseObj
 from easyscience.base_classes import CollectionBase
@@ -224,18 +241,18 @@ class Phases(CollectionBase): ...
 
 ### PR1: Base Class Replacements
 
-| Task | Files Modified |
-|------|----------------|
-| Create `BaseCore` class (based on EasyReflectometryLib pattern) | New: `Components/base_core.py` |
-| Create `BaseCollection` class | New: `Components/base_collection.py` |
-| Migrate `Lattice`, `PeriodicLattice` | `Components/Lattice.py` |
-| Migrate `Site`, `PeriodicSite`, `Atoms`, `PeriodicAtoms` | `Components/Site.py` |
-| Migrate `AdpBase` and subclasses, `AtomicDisplacement` | `Components/AtomicDisplacement.py` |
-| Migrate `SpaceGroup` | `Components/SpaceGroup.py` |
-| Migrate `MSPBase`, `Cani`, `Ciso`, `MagneticSusceptibility` | `Components/Susceptibility.py` |
-| Migrate `Phase`, `Phases` | `Structures/Phase.py` |
-| Update imports and exports | `__init__.py` files |
-| Fix tests | `tests/unit_tests/` |
+| Task                                                            | Files Modified                       |
+| --------------------------------------------------------------- | ------------------------------------ |
+| Create `BaseCore` class (based on EasyReflectometryLib pattern) | New: `Components/base_core.py`       |
+| Create `BaseCollection` class                                   | New: `Components/base_collection.py` |
+| Migrate `Lattice`, `PeriodicLattice`                            | `Components/Lattice.py`              |
+| Migrate `Site`, `PeriodicSite`, `Atoms`, `PeriodicAtoms`        | `Components/Site.py`                 |
+| Migrate `AdpBase` and subclasses, `AtomicDisplacement`          | `Components/AtomicDisplacement.py`   |
+| Migrate `SpaceGroup`                                            | `Components/SpaceGroup.py`           |
+| Migrate `MSPBase`, `Cani`, `Ciso`, `MagneticSusceptibility`     | `Components/Susceptibility.py`       |
+| Migrate `Phase`, `Phases`                                       | `Structures/Phase.py`                |
+| Update imports and exports                                      | `__init__.py` files                  |
+| Fix tests                                                       | `tests/unit_tests/`                  |
 
 ### PR2: Calculator Refactor
 
@@ -243,34 +260,36 @@ class Phases(CollectionBase): ...
 
 ### PR3: Interface Removal/Simplification
 
-| Task | Files Modified |
-|------|----------------|
-| Make `interface` parameter optional (default `None`) | All migrated files |
-| Make `generate_bindings` a no-op or conditional | `Components/Site.py` |
-| Document interface as passthrough for downstream use | Docstrings |
+| Task                                                 | Files Modified       |
+| ---------------------------------------------------- | -------------------- |
+| Make `interface` parameter optional (default `None`) | All migrated files   |
+| Make `generate_bindings` a no-op or conditional      | `Components/Site.py` |
+| Document interface as passthrough for downstream use | Docstrings           |
 
 ---
 
 ## 7. Migration Strategy Assessment
 
-| Aspect | Assessment | Risk Level | Notes |
-|--------|------------|------------|-------|
-| Backward Compatibility | Should be maintained | Medium | Library used by EasyDiffraction |
-| Class Hierarchy | Moderate complexity | Low | Fewer classes than EasyReflectometryLib |
-| Calculator Refactor | Not needed | None | No calculators in this package |
-| Interface Pattern | Passthrough only | Low | Simplify, don't remove |
-| Test Coverage | Limited (5 test files) | Medium | May need to add tests |
-| Serialization | Custom `as_dict` patterns | Medium | Follow EasyReflectometryLib pattern |
-| Parameter Dependencies | Used in `PeriodicLattice.enforce_sym()` | Low | Should work with new architecture |
+| Aspect                 | Assessment                              | Risk Level | Notes                                   |
+| ---------------------- | --------------------------------------- | ---------- | --------------------------------------- |
+| Backward Compatibility | Should be maintained                    | Medium     | Library used by EasyDiffraction         |
+| Class Hierarchy        | Moderate complexity                     | Low        | Fewer classes than EasyReflectometryLib |
+| Calculator Refactor    | Not needed                              | None       | No calculators in this package          |
+| Interface Pattern      | Passthrough only                        | Low        | Simplify, don't remove                  |
+| Test Coverage          | Limited (5 test files)                  | Medium     | May need to add tests                   |
+| Serialization          | Custom `as_dict` patterns               | Medium     | Follow EasyReflectometryLib pattern     |
+| Parameter Dependencies | Used in `PeriodicLattice.enforce_sym()` | Low        | Should work with new architecture       |
 
 ---
 
 ## 8. Dependencies and Impact
 
 ### Upstream Dependencies
+
 - `easyscience` (corelib) - Must have `ModelBase`, `ModelCollection` available
 
 ### Downstream Dependencies
+
 - **EasyDiffraction** - Primary consumer of EasyCrystallography
   - Uses `Phase`, `Phases`, `Lattice`, `Site`, `Atoms`, `SpaceGroup`
   - Provides its own calculator/interface that uses these objects
@@ -281,11 +300,13 @@ class Phases(CollectionBase): ...
 ## 9. Implementation Checklist
 
 ### Phase 1: Preparation
+
 - [ ] Verify corelib has required classes (`ModelBase`, `ModelCollection`)
 - [ ] Review EasyReflectometryLib implementation for patterns
 - [ ] Set up test environment
 
 ### Phase 2: Core Migration (PR1)
+
 - [ ] Create `BaseCore` compatibility class
 - [ ] Create `BaseCollection` compatibility class
 - [ ] Migrate `Lattice.py` classes
@@ -299,6 +320,7 @@ class Phases(CollectionBase): ...
 - [ ] Run full test suite
 
 ### Phase 3: Interface Simplification (PR3)
+
 - [ ] Make interface optional on all classes
 - [ ] Make `generate_bindings` conditional/no-op
 - [ ] Update documentation
@@ -309,6 +331,7 @@ class Phases(CollectionBase): ...
 ## 10. Test Requirements
 
 ### Existing Tests to Update
+
 - `tests/unit_tests/components/test_Atoms.py`
 - `tests/unit_tests/components/test_Lattice.py`
 - `tests/unit_tests/components/test_Site.py`
@@ -316,6 +339,7 @@ class Phases(CollectionBase): ...
 - `tests/unit_tests/io/test_star.py`
 
 ### New Tests to Add
+
 - Serialization round-trip tests (`as_dict` → `from_dict`)
 - Copy tests (`__copy__`, `__deepcopy__`)
 - Parameter dependency tests (for `PeriodicLattice`)
@@ -334,17 +358,23 @@ class Phases(CollectionBase): ...
 
 ### Potential Issues
 
-1. **PeriodicLattice symmetry constraints** - Uses `make_dependent_on()` for parameter dependencies
-2. **SpaceGroup complexity** - Complex class with many properties and class methods
-3. **Dynamic property addition** - `AtomicDisplacement` and `MagneticSusceptibility` use `addProp`/`removeProp`
+1. **PeriodicLattice symmetry constraints** - Uses `make_dependent_on()` for
+   parameter dependencies
+2. **SpaceGroup complexity** - Complex class with many properties and class
+   methods
+3. **Dynamic property addition** - `AtomicDisplacement` and
+   `MagneticSusceptibility` use `addProp`/`removeProp`
 
 ### Implementation Notes
 
-1. **`_get_symops_value` function in SpaceGroup.py** - Added to fix a line length linting error. The original code was a single-line lambda that exceeded the project's 127-character limit:
+1. **`_get_symops_value` function in SpaceGroup.py** - Added to fix a line
+   length linting error. The original code was a single-line lambda that
+   exceeded the project's 127-character limit:
+
    ```python
    # Before (141 characters - too long)
    _D_REDIRECT['value'] = lambda obj: ';'.join([r.as_xyz_string() for r in (obj.value.tolist() if hasattr(obj.value, 'tolist') else obj.value)])
-   
+
    # After (extracted to named function)
    def _get_symops_value(obj):
        ops = obj.value.tolist() if hasattr(obj.value, 'tolist') else obj.value
@@ -363,7 +393,7 @@ The same change made for EasyReflectometryLib should apply:
 if not isinstance(item, (BasedBase, DescriptorBase)):
     raise TypeError(...)
 
-# After  
+# After
 if not isinstance(item, (BasedBase, DescriptorBase, NewBase)):
     raise TypeError(...)
 ```

--- a/MIGRATION_ANALYSIS.md
+++ b/MIGRATION_ANALYSIS.md
@@ -1,0 +1,371 @@
+# EasyCrystallography Migration Analysis - Phase 1
+
+## Executive Summary
+
+This document contains the impact analysis for migrating EasyCrystallography from the old corelib architecture (`ObjBase`, `CollectionBase`) to the new architecture (`ModelBase`, `ModelCollection`, `CalculatorFactoryBase`).
+
+**Note:** EasyCrystallography is a simpler case than EasyReflectometryLib as it does not have its own calculator implementations. The `interface` parameter exists on objects but is passed through for downstream applications (like EasyDiffraction) to use.
+
+---
+
+## 1. Inheritance Tree Analysis
+
+### Current Architecture (Before Migration)
+
+```
+ObjBase (corelib - deprecated)
+├── Lattice (Components/Lattice.py)
+│   └── PeriodicLattice
+├── Site (Components/Site.py)
+│   └── PeriodicSite
+├── AdpBase (Components/AtomicDisplacement.py)
+│   ├── Anisotropic
+│   ├── Isotropic
+│   ├── AnisotropicBij
+│   └── IsotropicB
+├── AtomicDisplacement (Components/AtomicDisplacement.py)
+├── SpaceGroup (Components/SpaceGroup.py)
+├── MSPBase (Components/Susceptibility.py)
+│   ├── Cani
+│   └── Ciso
+├── MagneticSusceptibility (Components/Susceptibility.py)
+└── Phase (Structures/Phase.py)
+
+CollectionBase (corelib - deprecated)
+├── Atoms (Components/Site.py)
+│   └── PeriodicAtoms
+└── Phases (Structures/Phase.py)
+
+Other Classes (no migration needed):
+├── Specie (extends DescriptorStr)
+├── Twin (plain Python class)
+├── SymmOp (extends SerializerComponent)
+├── SymmetryGroup/PointGroup/SpaceGroup (Symmetry groups - abstract/metaclass)
+└── IO classes (template, parser, star classes)
+```
+
+### Target Architecture (After Migration)
+
+```
+ModelBase (corelib - new)
+├── BaseCore (new compatibility layer)
+│   ├── Lattice
+│   │   └── PeriodicLattice
+│   ├── Site
+│   │   └── PeriodicSite
+│   ├── AdpBase
+│   │   ├── Anisotropic
+│   │   ├── Isotropic
+│   │   ├── AnisotropicBij
+│   │   └── IsotropicB
+│   ├── AtomicDisplacement
+│   ├── SpaceGroup
+│   ├── MSPBase
+│   │   ├── Cani
+│   │   └── Ciso
+│   ├── MagneticSusceptibility
+│   └── Phase
+
+ModelCollection (corelib - new)
+├── BaseCollection (new compatibility layer)
+│   ├── Atoms
+│   │   └── PeriodicAtoms
+│   └── Phases
+```
+
+---
+
+## 2. Calculator/Interface Analysis
+
+### Current Pattern
+
+Unlike EasyReflectometryLib, EasyCrystallography does **not** have its own calculator implementations. The `interface` parameter is:
+
+1. **Accepted** by constructors on most classes (Lattice, Site, Phase, etc.)
+2. **Stored** on the object as `self.interface`
+3. **Used minimally** - only `Site.add_adp()` calls `self.interface.generate_bindings(self)` (line 205)
+4. **Passed through** to downstream applications like EasyDiffraction
+
+### Migration Approach
+
+Since there's no CalculatorFactory in EasyCrystallography:
+
+1. **No PR2 equivalent needed** - No calculator refactoring required
+2. **Interface parameter** should be made optional with `None` default
+3. **generate_bindings calls** in `Site.add_adp()` should be made conditional or removed
+4. The `interface` can remain as a passthrough for downstream compatibility
+
+---
+
+## 3. Breaking Changes Inventory
+
+| Component | Old API | New API | Breaking Change | Mitigation |
+|-----------|---------|---------|-----------------|------------|
+| All `ObjBase` classes | Inherits `ObjBase` | Inherits `ModelBase` via `BaseCore` | Constructor signature | Add compatibility `__init__` |
+| `name` property | Direct from `ObjBase` | Maps to `display_name` | Property access | Property wrapper in `BaseCore` |
+| `interface` property | Direct property | Keep for downstream compat | None | Keep as optional parameter |
+| `Atoms`, `Phases` | Inherits `CollectionBase` | Inherits `ModelCollection` via `BaseCollection` | Constructor signature | Add compatibility `__init__` |
+| Serialization | `as_dict()` custom patterns | `to_dict()` from SerializerBase | Method names | Alias methods |
+| Object creation | `name` parameter | `unique_name` + `display_name` | Parameter naming | Map in constructor |
+| Parameter access | `self.kwarg_name` magic | Explicit or via `_kwargs` | Attribute access | Custom `__getattr__` |
+
+---
+
+## 4. Files Affected by Migration
+
+### Core Files to Modify (PR1: Base Class Replacements)
+
+| File | Current Base | Target Base | Changes Required |
+|------|--------------|-------------|------------------|
+| `Components/Lattice.py` | `ObjBase` | `BaseCore` | Update import, change base class |
+| `Components/Site.py` | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes, handle interface |
+| `Components/AtomicDisplacement.py` | `ObjBase` | `BaseCore` | Update import, change base class |
+| `Components/SpaceGroup.py` | `ObjBase` | `BaseCore` | Update import, change base class |
+| `Components/Susceptibility.py` | `ObjBase` | `BaseCore` | Update import, change base class |
+| `Structures/Phase.py` | `ObjBase`, `CollectionBase` | `BaseCore`, `BaseCollection` | Update imports, change base classes |
+
+### New Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Components/base_core.py` | Compatibility layer between `ModelBase` and legacy patterns |
+| `Components/base_collection.py` (or in same file) | Compatibility layer for collections |
+
+### Files with Minor Changes
+
+| File | Changes Required |
+|------|------------------|
+| `Components/__init__.py` | Export new base classes if needed |
+| `Structures/__init__.py` | Export new base classes if needed |
+
+---
+
+## 5. Class-by-Class Migration Details
+
+### 5.1 Lattice (Components/Lattice.py)
+
+**Current:**
+```python
+from easyscience import ObjBase as BaseObj
+
+class Lattice(BaseObj):
+    def __init__(self, ..., interface: Optional[iF] = None, ...):
+        super().__init__('lattice', length_a=..., ...)
+        self.interface = interface
+```
+
+**Target:**
+```python
+from easycrystallography.Components.base_core import BaseCore
+
+class Lattice(BaseCore):
+    def __init__(self, ..., interface=None, ...):
+        super().__init__('lattice', interface=interface, 
+                         length_a=..., ...)
+```
+
+### 5.2 Site (Components/Site.py)
+
+**Current:**
+```python
+from easyscience import ObjBase as BaseObj
+from easyscience.base_classes import CollectionBase
+
+class Site(BaseObj): ...
+class Atoms(CollectionBase): ...
+```
+
+**Target:**
+```python
+from easycrystallography.Components.base_core import BaseCore
+from easycrystallography.Components.base_collection import BaseCollection
+
+class Site(BaseCore): ...
+class Atoms(BaseCollection): ...
+```
+
+**Special handling:**
+- `Site.add_adp()` has `self.interface.generate_bindings(self)` - make conditional
+
+### 5.3 AtomicDisplacement (Components/AtomicDisplacement.py)
+
+**Classes to migrate:** `AdpBase`, `Anisotropic`, `Isotropic`, `AnisotropicBij`, `IsotropicB`, `AtomicDisplacement`
+
+### 5.4 SpaceGroup (Components/SpaceGroup.py)
+
+**Current:**
+```python
+from easyscience import ObjBase as BaseObj
+
+class SpaceGroup(BaseObj):
+    def __init__(self, ..., interface: Optional[iF] = None):
+        super(SpaceGroup, self).__init__('space_group', ...)
+        self.interface = interface
+```
+
+### 5.5 Susceptibility (Components/Susceptibility.py)
+
+**Classes to migrate:** `MSPBase`, `Cani`, `Ciso`, `MagneticSusceptibility`
+
+### 5.6 Phase (Structures/Phase.py)
+
+**Current:**
+```python
+from easyscience import ObjBase as BaseObj
+from easyscience.base_classes import CollectionBase
+
+class Phase(BaseObj): ...
+class Phases(CollectionBase): ...
+```
+
+---
+
+## 6. Pull Request Strategy
+
+### PR1: Base Class Replacements
+
+| Task | Files Modified |
+|------|----------------|
+| Create `BaseCore` class (based on EasyReflectometryLib pattern) | New: `Components/base_core.py` |
+| Create `BaseCollection` class | New: `Components/base_collection.py` |
+| Migrate `Lattice`, `PeriodicLattice` | `Components/Lattice.py` |
+| Migrate `Site`, `PeriodicSite`, `Atoms`, `PeriodicAtoms` | `Components/Site.py` |
+| Migrate `AdpBase` and subclasses, `AtomicDisplacement` | `Components/AtomicDisplacement.py` |
+| Migrate `SpaceGroup` | `Components/SpaceGroup.py` |
+| Migrate `MSPBase`, `Cani`, `Ciso`, `MagneticSusceptibility` | `Components/Susceptibility.py` |
+| Migrate `Phase`, `Phases` | `Structures/Phase.py` |
+| Update imports and exports | `__init__.py` files |
+| Fix tests | `tests/unit_tests/` |
+
+### PR2: Calculator Refactor
+
+**Not applicable** - EasyCrystallography does not have its own calculators.
+
+### PR3: Interface Removal/Simplification
+
+| Task | Files Modified |
+|------|----------------|
+| Make `interface` parameter optional (default `None`) | All migrated files |
+| Make `generate_bindings` a no-op or conditional | `Components/Site.py` |
+| Document interface as passthrough for downstream use | Docstrings |
+
+---
+
+## 7. Migration Strategy Assessment
+
+| Aspect | Assessment | Risk Level | Notes |
+|--------|------------|------------|-------|
+| Backward Compatibility | Should be maintained | Medium | Library used by EasyDiffraction |
+| Class Hierarchy | Moderate complexity | Low | Fewer classes than EasyReflectometryLib |
+| Calculator Refactor | Not needed | None | No calculators in this package |
+| Interface Pattern | Passthrough only | Low | Simplify, don't remove |
+| Test Coverage | Limited (5 test files) | Medium | May need to add tests |
+| Serialization | Custom `as_dict` patterns | Medium | Follow EasyReflectometryLib pattern |
+| Parameter Dependencies | Used in `PeriodicLattice.enforce_sym()` | Low | Should work with new architecture |
+
+---
+
+## 8. Dependencies and Impact
+
+### Upstream Dependencies
+- `easyscience` (corelib) - Must have `ModelBase`, `ModelCollection` available
+
+### Downstream Dependencies
+- **EasyDiffraction** - Primary consumer of EasyCrystallography
+  - Uses `Phase`, `Phases`, `Lattice`, `Site`, `Atoms`, `SpaceGroup`
+  - Provides its own calculator/interface that uses these objects
+  - Migration should maintain interface compatibility
+
+---
+
+## 9. Implementation Checklist
+
+### Phase 1: Preparation
+- [ ] Verify corelib has required classes (`ModelBase`, `ModelCollection`)
+- [ ] Review EasyReflectometryLib implementation for patterns
+- [ ] Set up test environment
+
+### Phase 2: Core Migration (PR1)
+- [ ] Create `BaseCore` compatibility class
+- [ ] Create `BaseCollection` compatibility class
+- [ ] Migrate `Lattice.py` classes
+- [ ] Migrate `Site.py` classes
+- [ ] Migrate `AtomicDisplacement.py` classes
+- [ ] Migrate `SpaceGroup.py`
+- [ ] Migrate `Susceptibility.py` classes
+- [ ] Migrate `Phase.py` classes
+- [ ] Update all `__init__.py` exports
+- [ ] Fix all tests
+- [ ] Run full test suite
+
+### Phase 3: Interface Simplification (PR3)
+- [ ] Make interface optional on all classes
+- [ ] Make `generate_bindings` conditional/no-op
+- [ ] Update documentation
+- [ ] Verify downstream compatibility
+
+---
+
+## 10. Test Requirements
+
+### Existing Tests to Update
+- `tests/unit_tests/components/test_Atoms.py`
+- `tests/unit_tests/components/test_Lattice.py`
+- `tests/unit_tests/components/test_Site.py`
+- `tests/unit_tests/components/test_SpaceGroup.py`
+- `tests/unit_tests/io/test_star.py`
+
+### New Tests to Add
+- Serialization round-trip tests (`as_dict` → `from_dict`)
+- Copy tests (`__copy__`, `__deepcopy__`)
+- Parameter dependency tests (for `PeriodicLattice`)
+- Collection manipulation tests
+
+---
+
+## 11. Notes and Considerations
+
+### Key Differences from EasyReflectometryLib
+
+1. **No calculators** - Simpler migration, no PR2 equivalent
+2. **Interface is passthrough** - Keep for downstream compatibility
+3. **Fewer tests** - May need to add tests during migration
+4. **Used by EasyDiffraction** - Must maintain API compatibility
+
+### Potential Issues
+
+1. **PeriodicLattice symmetry constraints** - Uses `make_dependent_on()` for parameter dependencies
+2. **SpaceGroup complexity** - Complex class with many properties and class methods
+3. **Dynamic property addition** - `AtomicDisplacement` and `MagneticSusceptibility` use `addProp`/`removeProp`
+
+### Implementation Notes
+
+1. **`_get_symops_value` function in SpaceGroup.py** - Added to fix a line length linting error. The original code was a single-line lambda that exceeded the project's 127-character limit:
+   ```python
+   # Before (141 characters - too long)
+   _D_REDIRECT['value'] = lambda obj: ';'.join([r.as_xyz_string() for r in (obj.value.tolist() if hasattr(obj.value, 'tolist') else obj.value)])
+   
+   # After (extracted to named function)
+   def _get_symops_value(obj):
+       ops = obj.value.tolist() if hasattr(obj.value, 'tolist') else obj.value
+       return ';'.join([r.as_xyz_string() for r in ops])
+   _D_REDIRECT['value'] = _get_symops_value
+   ```
+
+### Corelib Changes Required
+
+The same change made for EasyReflectometryLib should apply:
+
+**File:** `corelib/src/easyscience/base_classes/collection_base.py`
+
+```python
+# Before
+if not isinstance(item, (BasedBase, DescriptorBase)):
+    raise TypeError(...)
+
+# After  
+if not isinstance(item, (BasedBase, DescriptorBase, NewBase)):
+    raise TypeError(...)
+```
+
+This allows `ModelCollection` to accept objects that inherit from `ModelBase`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ classifiers = [
 ]
 requires-python = '>=3.11,<3.14'
 dependencies = [
-  'asteval',       # For evaluating mathematical expressions
-  'easyscience',   # The base library of the EasyScience framework
-  'gemmi',         # For handling CIF files
-  'numpy',         # For numerical calculations
-  'periodictable', # For atomic properties
-  'uncertainties', # For error propagation
-  'versioningit',  # For versioning
-  'xarray',        # For handling data arrays
+  'asteval',                                                                             # For evaluating mathematical expressions
+  'easyscience @ git+https://github.com/easyscience/corelib.git@new_calculator_factory',
+  'gemmi',                                                                               # For handling CIF files
+  'numpy',                                                                               # For numerical calculations
+  'periodictable',                                                                       # For atomic properties
+  'uncertainties',                                                                       # For error propagation
+  'versioningit',                                                                        # For versioning
+  'xarray',                                                                              # For handling data arrays
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   'build',        # For building the package
+  'codecov',      # For code coverage
   'pytest',       # For testing
   'pytest-xdist', # For parallel testing
   'pytest-cov',   # For coverage

--- a/src/easycrystallography/Components/AtomicDisplacement.py
+++ b/src/easycrystallography/Components/AtomicDisplacement.py
@@ -12,11 +12,12 @@ from typing import TypeVar
 from typing import Union
 
 import numpy as np
-from easyscience import ObjBase as BaseObj
 from easyscience.utils.classTools import addProp
 from easyscience.utils.classTools import removeProp
 from easyscience.variable import DescriptorStr
 from easyscience.variable import Parameter
+
+from .base_core import BaseCore
 
 if TYPE_CHECKING:
     from easyscience.utils.typing import iF
@@ -68,7 +69,7 @@ _ANIO_DETAILS = {
 }
 
 
-class AdpBase(BaseObj):
+class AdpBase(BaseCore):
     def __init__(self, *args, **kwargs):
         super(AdpBase, self).__init__(*args, **kwargs)
 
@@ -116,6 +117,7 @@ class Anisotropic(AdpBase):
     ):
         super(Anisotropic, self).__init__(
             'anisoU',
+            interface=interface,
             U_11=Parameter('U_11', **_ANIO_DETAILS['Uani']),
             U_12=Parameter('U_12', **_ANIO_DETAILS['Uani']),
             U_13=Parameter('U_13', **_ANIO_DETAILS['Uani']),
@@ -140,7 +142,6 @@ class Anisotropic(AdpBase):
         else:
             # for cubic, tetragonal, and orthorhombic systems
             self.Uiso_ani = (self.U_11.value + self.U_22.value + self.U_33.value) / 3.0
-        self.interface = interface
 
 
 class Isotropic(AdpBase):
@@ -151,10 +152,9 @@ class Isotropic(AdpBase):
         Uiso: Optional[Union[Parameter, float]] = None,
         interface: Optional[iF] = None,
     ):
-        super(Isotropic, self).__init__('Uiso', Uiso=Parameter('Uiso', **_ANIO_DETAILS['Uiso']))
+        super(Isotropic, self).__init__('Uiso', interface=interface, Uiso=Parameter('Uiso', **_ANIO_DETAILS['Uiso']))
         if Uiso is not None:
             self.Uiso = Uiso
-        self.interface = interface
 
 
 class AnisotropicBij(AdpBase):
@@ -177,6 +177,7 @@ class AnisotropicBij(AdpBase):
     ):
         super(AnisotropicBij, self).__init__(
             'anisoB',
+            interface=interface,
             **{name: Parameter(name, **_ANIO_DETAILS['Bani']) for name in ['B_11', 'B_12', 'B_13', 'B_22', 'B_23', 'B_33']},
         )
         if B_11 is not None:
@@ -191,7 +192,6 @@ class AnisotropicBij(AdpBase):
             self.B_23 = B_23
         if B_33 is not None:
             self.B_33 = B_33
-        self.interface = interface
 
 
 class IsotropicB(AdpBase):
@@ -202,10 +202,9 @@ class IsotropicB(AdpBase):
         Biso: Optional[Union[Parameter, float]] = None,
         interface: Optional[iF] = None,
     ):
-        super(IsotropicB, self).__init__('Biso', Biso=Parameter('Biso', **_ANIO_DETAILS['Biso']))
+        super(IsotropicB, self).__init__('Biso', interface=interface, Biso=Parameter('Biso', **_ANIO_DETAILS['Biso']))
         if Biso is not None:
             self.Biso = Biso
-        self.interface = interface
 
 
 _AVAILABLE_ISO_TYPES = {
@@ -222,7 +221,7 @@ if TYPE_CHECKING:
     AB = TypeVar('AB', bound=AdpBase)
 
 
-class AtomicDisplacement(BaseObj):
+class AtomicDisplacement(BaseCore):
     adp_type: ClassVar[DescriptorStr]
     adp_class: ClassVar[AB]
 
@@ -247,7 +246,7 @@ class AtomicDisplacement(BaseObj):
             adp = adp_class(**kwargs, interface=interface)
         else:
             raise AttributeError(f'{adp_class_name} is not a valid adp type')
-        super(AtomicDisplacement, self).__init__('adp', adp_type=adp_type, adp_class=adp)
+        super(AtomicDisplacement, self).__init__('adp', interface=interface, adp_type=adp_type, adp_class=adp)
         for par in adp.get_parameters():
             addProp(
                 self,
@@ -255,7 +254,6 @@ class AtomicDisplacement(BaseObj):
                 fget=self.__a_getter(par.name),
                 fset=self.__a_setter(par.name),
             )
-        self.interface = interface
 
     def switch_type(self, adp_string: str, **kwargs):
         # if adp_string in _AVAILABLE_ISO_TYPES.keys():

--- a/src/easycrystallography/Components/Lattice.py
+++ b/src/easycrystallography/Components/Lattice.py
@@ -22,10 +22,10 @@ from typing import TypeVar
 from typing import Union
 
 import numpy as np
-from easyscience import ObjBase as BaseObj
 from easyscience.utils.decorators import memoized
 from easyscience.variable import Parameter
 
+from .base_core import BaseCore
 from .SpaceGroup import SpaceGroup
 
 Vector3Like = Union[List[float], np.ndarray]
@@ -56,7 +56,7 @@ CELL_DETAILS = {
 }
 
 
-class Lattice(BaseObj):
+class Lattice(BaseCore):
     _REDIRECT = {'ang_unit': None}
 
     length_a: ClassVar[Parameter]
@@ -83,6 +83,7 @@ class Lattice(BaseObj):
 
         super().__init__(
             'lattice',
+            interface=interface,
             length_a=Parameter('length_a', **THESE_CELL_DETAILS['length']),
             length_b=Parameter('length_b', **THESE_CELL_DETAILS['length']),
             length_c=Parameter('length_c', **THESE_CELL_DETAILS['length']),
@@ -109,8 +110,6 @@ class Lattice(BaseObj):
             self.angle_alpha.convert_unit(CELL_DETAILS['angle']['unit'])
             self.angle_beta.convert_unit(CELL_DETAILS['angle']['unit'])
             self.angle_gamma.convert_unit(CELL_DETAILS['angle']['unit'])
-
-        self.interface = interface
 
     @classmethod
     def from_matrix(
@@ -746,6 +745,7 @@ class PeriodicLattice(Lattice):
             angle_alpha=angle_alpha,
             angle_beta=angle_beta,
             angle_gamma=angle_gamma,
+            interface=interface,
             spacegroup=SpaceGroup('P1'),
         )
         if spacegroup is not None:
@@ -762,7 +762,6 @@ class PeriodicLattice(Lattice):
             fdel=spacegroup.__class__.space_group_HM_name.fdel,
         )
 
-        self.interface = interface
         self.enforce_sym()
 
     @classmethod

--- a/src/easycrystallography/Components/Site.py
+++ b/src/easycrystallography/Components/Site.py
@@ -13,12 +13,12 @@ from typing import TypeVar
 from typing import Union
 
 import numpy as np
-from easyscience import ObjBase as BaseObj
-from easyscience.base_classes import CollectionBase
 from easyscience.variable import DescriptorStr
 from easyscience.variable import Parameter
 
 from .AtomicDisplacement import AtomicDisplacement
+from .base_collection import BaseCollection
+from .base_core import BaseCore
 from .Lattice import PeriodicLattice
 from .Specie import Specie
 from .Susceptibility import MagneticSusceptibility
@@ -50,7 +50,7 @@ _SITE_DETAILS = {
 S = TypeVar('S', bound='Site')
 
 
-class Site(BaseObj):
+class Site(BaseCore):
     label: ClassVar[DescriptorStr]
     specie: ClassVar[Specie]
     occupancy: ClassVar[Parameter]
@@ -111,6 +111,7 @@ class Site(BaseObj):
 
         super(Site, self).__init__(
             'site',
+            interface=interface,
             label=DescriptorStr('label', **_SITE_DETAILS['label']),
             specie=Specie(_SITE_DETAILS['label']['value']),
             occupancy=Parameter('occupancy', **_SITE_DETAILS['occupancy']),
@@ -134,7 +135,6 @@ class Site(BaseObj):
             self.fract_y = fract_y
         if fract_z is not None:
             self.fract_z = fract_z
-        self.interface = interface
 
     def __repr__(self) -> str:
         return f'Atom {self.name} ({self.specie.value}) @ ({self.fract_x.value}, {self.fract_y.value}, {self.fract_z.value})'
@@ -225,11 +225,10 @@ class PeriodicSite(Site):
         interface: Optional[iF] = None,
         **kwargs,
     ):
-        super(PeriodicSite, self).__init__(label, specie, occupancy, fract_x, fract_y, fract_z, **kwargs)
+        super(PeriodicSite, self).__init__(label, specie, occupancy, fract_x, fract_y, fract_z, interface=interface, **kwargs)
         if lattice is None:
             lattice = PeriodicLattice()
         self.lattice = lattice
-        self.interface = interface
 
     @staticmethod
     def _from_site_kwargs(lattice: PeriodicLattice, site: S) -> Dict[str, float]:
@@ -271,20 +270,18 @@ class PeriodicSite(Site):
         return self.lattice.get_cartesian_coords(self.fract_coords)
 
 
-class Atoms(CollectionBase):
+class Atoms(BaseCollection):
     _SITE_CLASS = Site
 
     def __init__(self, name: str, *args, interface: Optional[iF] = None, **kwargs):
         if not isinstance(name, str):
             raise TypeError('A `name` for this collection must be given in string form')
-        super(Atoms, self).__init__(name, *args, **kwargs)
-        self.interface = interface
-        self._kwargs._stack_enabled = True
+        super(Atoms, self).__init__(name, *args, interface=interface, **kwargs)
 
     def __repr__(self) -> str:
         return f'Collection of {len(self)} sites.'
 
-    def __getitem__(self, idx: Union[int, slice, str]) -> Union[Parameter, DescriptorStr, BaseObj, 'CollectionBase']:
+    def __getitem__(self, idx: Union[int, slice, str]) -> Union[Parameter, DescriptorStr, BaseCore, 'BaseCollection']:
         if isinstance(idx, str) and idx in self.atom_labels:
             idx = self.atom_labels.index(idx)
         return super(Atoms, self).__getitem__(idx)

--- a/src/easycrystallography/Components/SpaceGroup.py
+++ b/src/easycrystallography/Components/SpaceGroup.py
@@ -15,10 +15,10 @@ from typing import Union
 
 import gemmi
 import numpy as np
-from easyscience import ObjBase as BaseObj
 from easyscience.variable import DescriptorAnyType
 from easyscience.variable import DescriptorStr
 
+from easycrystallography.Components.base_core import BaseCore
 from easycrystallography.Symmetry.functions import get_default_it_coordinate_system_code_by_it_number
 from easycrystallography.Symmetry.functions import get_spacegroup_by_name_ext
 from easycrystallography.Symmetry.SymOp import SymmOp
@@ -55,14 +55,22 @@ if TYPE_CHECKING:
 
 
 _D_REDIRECT = deepcopy(DescriptorStr._REDIRECT)
-_D_REDIRECT['value'] = lambda obj: ';'.join([r.as_xyz_string() for r in obj.value.tolist()])
+
+
+def _get_symops_value(obj):
+    """Helper function to serialize symmetry operations."""
+    ops = obj.value.tolist() if hasattr(obj.value, 'tolist') else obj.value
+    return ';'.join([r.as_xyz_string() for r in ops])
+
+
+_D_REDIRECT['value'] = _get_symops_value
 
 
 class easyOp(DescriptorAnyType):
     _REDIRECT = _D_REDIRECT
 
 
-class SpaceGroup(BaseObj):
+class SpaceGroup(BaseCore):
     _space_group_HM_name: ClassVar[DescriptorStr]
     _setting: ClassVar[DescriptorStr]
     _symmetry_ops: ClassVar[DescriptorAnyType]
@@ -87,6 +95,7 @@ class SpaceGroup(BaseObj):
 
         super(SpaceGroup, self).__init__(
             'space_group',
+            interface=interface,
             _space_group_HM_name=DescriptorStr(**SG_DETAILS['space_group_HM_name']),
             _setting=DescriptorStr(**SG_DETAILS['setting']),
             _symmetry_ops=easyOp(**SG_DETAILS['symmetry_ops']),
@@ -112,7 +121,6 @@ class SpaceGroup(BaseObj):
         if symmetry_ops is not None:
             kwargs['operations_set'] = symmetry_ops
         self.__on_change(**kwargs)
-        self.interface = interface
         self._cell = None
 
     @classmethod

--- a/src/easycrystallography/Components/Susceptibility.py
+++ b/src/easycrystallography/Components/Susceptibility.py
@@ -12,11 +12,12 @@ from typing import Type
 from typing import Union
 
 import numpy as np
-from easyscience import ObjBase as BaseObj
 from easyscience.utils.classTools import addProp
 from easyscience.utils.classTools import removeProp
 from easyscience.variable import DescriptorStr
 from easyscience.variable import Parameter
+
+from .base_core import BaseCore
 
 if TYPE_CHECKING:
     from easyscience.utils.typing import iF
@@ -46,7 +47,7 @@ _ANIO_DETAILS = {
 }
 
 
-class MSPBase(BaseObj):
+class MSPBase(BaseCore):
     def __init__(self, *args, **kwargs):
         super(MSPBase, self).__init__(*args, **kwargs)
 
@@ -87,6 +88,7 @@ class Cani(MSPBase):
     ):
         super(Cani, self).__init__(
             'Cani',
+            interface=interface,
             chi_11=Parameter('chi_11', **_ANIO_DETAILS['Cani']),
             chi_12=Parameter('chi_12', **_ANIO_DETAILS['Cani']),
             chi_13=Parameter('chi_13', **_ANIO_DETAILS['Cani']),
@@ -113,7 +115,6 @@ class Cani(MSPBase):
             self.chi_22 = msp_values.chi_22
             self.chi_23 = msp_values.chi_23
             self.chi_33 = msp_values.chi_33
-        self.interface = interface
 
 
 class Ciso(MSPBase):
@@ -125,18 +126,17 @@ class Ciso(MSPBase):
         msp_values: Optional[Type[MSPBase]] = None,
         interface: Optional[iF] = None,
     ):
-        super(Ciso, self).__init__('Ciso', chi=Parameter('chi', **_ANIO_DETAILS['Ciso']))
+        super(Ciso, self).__init__('Ciso', interface=interface, chi=Parameter('chi', **_ANIO_DETAILS['Ciso']))
         if chi is not None:
             self.chi = chi
         if msp_values is not None:
             self.chi = msp_values.chi
-        self.interface = interface
 
 
 _AVAILABLE_ISO_TYPES = {'Cani': Cani, 'Ciso': Ciso}
 
 
-class MagneticSusceptibility(BaseObj):
+class MagneticSusceptibility(BaseCore):
     msp_type: ClassVar[DescriptorStr]
     msp_class: ClassVar[Type[MSPBase]]
 
@@ -153,7 +153,7 @@ class MagneticSusceptibility(BaseObj):
             msp = msp_class(**kwargs, interface=interface)
         else:
             raise AttributeError(f'{msp_class_name} is not a valid magnetic susceptibility type')
-        super(MagneticSusceptibility, self).__init__('msp', msp_type=msp_type, msp_class=msp)
+        super(MagneticSusceptibility, self).__init__('msp', interface=interface, msp_type=msp_type, msp_class=msp)
         for par in msp.get_parameters():
             addProp(
                 self,
@@ -161,7 +161,6 @@ class MagneticSusceptibility(BaseObj):
                 fget=self.__a_getter(par.name),
                 fset=self.__a_setter(par.name),
             )
-        self.interface = interface
 
     def switch_type(self, msp_string: str, **kwargs):
         if msp_string in _AVAILABLE_ISO_TYPES.keys():

--- a/src/easycrystallography/Components/base_collection.py
+++ b/src/easycrystallography/Components/base_collection.py
@@ -62,11 +62,29 @@ class BaseCollection(EasyModelCollection):
             extra_items = [item[1] for item in numeric_items]
             args = args + tuple(extra_items)
 
-        super().__init__(name, *args, interface=interface, unique_name=unique_name)
+        super().__init__(*args, interface=interface, unique_name=unique_name, display_name=name)
 
         # Needed to ensure an empty list is created when saving and instantiating the object as_dict -> from_dict
         # Else collisions might occur in global_object.map
         self.populate_if_none = remaining_kwargs.get('populate_if_none', False)
+
+    @property
+    def name(self) -> str:
+        """Get the name of the collection.
+
+        This is an alias for display_name to maintain backwards compatibility.
+
+        :return: Name of the collection.
+        """
+        return self.display_name
+
+    @name.setter
+    def name(self, new_name: str) -> None:
+        """Set the name of the collection.
+
+        :param new_name: New name for the collection.
+        """
+        self.display_name = new_name
 
     def get_parameters(self) -> List[Parameter]:
         """Get all parameter objects as a list.

--- a/src/easycrystallography/Components/base_collection.py
+++ b/src/easycrystallography/Components/base_collection.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2024 EasyCrystallography contributors
+# SPDX-License-Identifier: BSD-3-Clause
+# © 2022-2024 Contributors to the EasyCrystallography project <https://github.com/EasyScience/EasyCrystallography>
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from easyscience import global_object
+from easyscience.base_classes import ModelCollection as EasyModelCollection
+from easyscience.io.serializer_base import SerializerBase
+from easyscience.variable import Parameter
+
+if TYPE_CHECKING:
+    from easyscience.fitting.calculators import InterfaceFactoryTemplate
+
+
+class BaseCollection(EasyModelCollection):
+    """Base class for all EasyCrystallography collection objects.
+
+    This class bridges the new ModelCollection API with the legacy patterns
+    used throughout EasyCrystallography.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *args,
+        interface: Optional[InterfaceFactoryTemplate] = None,
+        unique_name: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Initialize the base collection.
+
+        :param name: Name for the collection
+        :param args: Items to add to the collection
+        :param interface: Optional interface for downstream calculator bindings
+        :param unique_name: Optional unique identifier
+        :param kwargs: Additional keyword arguments
+        """
+        if unique_name is None:
+            unique_name = global_object.generate_unique_name(self.__class__.__name__)
+
+        # Handle legacy pattern where items are passed as kwargs with numeric string keys
+        # e.g., {'0': item1, '1': item2} - convert these to positional args
+        numeric_items = []
+        remaining_kwargs = {}
+        for key, value in kwargs.items():
+            if key.isdigit():
+                numeric_items.append((int(key), value))
+            else:
+                remaining_kwargs[key] = value
+
+        # Sort by numeric key and extract values
+        if numeric_items:
+            numeric_items.sort(key=lambda x: x[0])
+            extra_items = [item[1] for item in numeric_items]
+            args = args + tuple(extra_items)
+
+        super().__init__(name, *args, interface=interface, unique_name=unique_name)
+
+        # Needed to ensure an empty list is created when saving and instantiating the object as_dict -> from_dict
+        # Else collisions might occur in global_object.map
+        self.populate_if_none = remaining_kwargs.get('populate_if_none', False)
+
+    def get_parameters(self) -> List[Parameter]:
+        """Get all parameter objects as a list.
+
+        This is an alias for get_all_parameters to maintain backwards compatibility.
+
+        :return: List of `Parameter` objects.
+        """
+        par_list = []
+        for item in self:
+            if hasattr(item, 'get_parameters'):
+                par_list.extend(item.get_parameters())
+        return par_list
+
+    def __repr__(self) -> str:
+        """String representation of the collection."""
+        return f'{self.__class__.__name__} `{self.name}` of length {len(self)}'
+
+    @property
+    def names(self) -> list:
+        """
+        :returns: list of names for the elements in the collection.
+        """
+        return [i.name for i in self]
+
+    def move_up(self, index: int):
+        """Move the element at the given index up in the collection.
+
+        :param index: Index of the element to move up.
+        """
+        if index == 0:
+            return
+        self.insert(index - 1, self.pop(index))
+
+    def move_down(self, index: int):
+        """Move the element at the given index down in the collection.
+
+        :param index: Index of the element to move down.
+        """
+        if index == len(self) - 1:
+            return
+        self.insert(index + 1, self.pop(index))
+
+    def remove(self, index: int):
+        """
+        Remove an element from the elements.
+
+        :param index: Index of the element to remove
+        """
+        self.pop(index)
+
+    def as_dict(self, skip: Optional[List[str]] = None) -> dict:
+        """
+        Create a dictionary representation of the collection.
+
+        :return: A dictionary representation of the collection
+        """
+        if skip is None:
+            skip = []
+
+        # Always skip unique_name for nested Parameters to avoid collisions during from_dict
+        param_skip = list(skip) + ['unique_name'] if 'unique_name' not in skip else list(skip)
+
+        this_dict = {
+            '@module': self.__class__.__module__,
+            '@class': self.__class__.__name__,
+            '@version': None,
+            'name': self.name,
+        }
+
+        # Add unique_name if not default
+        if 'unique_name' not in skip and not self._default_unique_name:
+            this_dict['unique_name'] = self.unique_name
+
+        this_dict['data'] = []
+        for collection_element in self:
+            if hasattr(collection_element, 'as_dict'):
+                this_dict['data'].append(collection_element.as_dict(skip=param_skip))
+            elif hasattr(collection_element, 'to_dict'):
+                this_dict['data'].append(collection_element.to_dict(skip=param_skip))
+            else:
+                this_dict['data'].append(collection_element)
+        this_dict['populate_if_none'] = self.populate_if_none
+        return this_dict
+
+    def to_dict(self, skip: Optional[List[str]] = None) -> dict:
+        """Convert to dictionary for serialization (alias for as_dict).
+
+        This overrides NewBase.to_dict to use our custom serialization.
+
+        :param skip: List of keys to skip, defaults to `None`.
+        :return: Dictionary representation of the collection.
+        """
+        return self.as_dict(skip=skip)
+
+    def __deepcopy__(self, memo):
+        return self.from_dict(self.as_dict(skip=['unique_name']))
+
+    @classmethod
+    def from_dict(cls, obj_dict: Dict[str, Any]) -> 'BaseCollection':
+        """
+        Re-create a collection from a dictionary.
+
+        :param obj_dict: Dictionary containing the serialized contents.
+        :return: Reformed collection object.
+        """
+        if not SerializerBase._is_serialized_easyscience_object(obj_dict):
+            raise ValueError('Input must be a dictionary representing an EasyScience object.')
+
+        # Extract data items and deserialize them
+        data_items = obj_dict.get('data', [])
+        deserialized_items = []
+        for item_dict in data_items:
+            if isinstance(item_dict, dict) and SerializerBase._is_serialized_easyscience_object(item_dict):
+                # Get the class and deserialize
+                deserialized_item = SerializerBase._deserialize_value(item_dict)
+                deserialized_items.append(deserialized_item)
+            else:
+                deserialized_items.append(item_dict)
+
+        # Build kwargs without data
+        name = obj_dict.get('name', cls.__name__)
+        unique_name = obj_dict.get('unique_name', None)
+        populate_if_none = obj_dict.get('populate_if_none', False)
+
+        # Create instance with items as positional args
+        instance = cls(name, *deserialized_items, unique_name=unique_name, populate_if_none=populate_if_none)
+        return instance

--- a/src/easycrystallography/Components/base_core.py
+++ b/src/easycrystallography/Components/base_core.py
@@ -24,11 +24,29 @@ class BaseCore(ModelBase):
     """Base class for all EasyCrystallography model objects.
 
     This class bridges the new ModelBase API with the legacy 'name' patterns
-    used throughout EasyCrystallography. The 'name' property maps to 'display_name' in the
-    new architecture.
+    used throughout EasyCrystallography. The 'name' property maps to 'display_name'
+    in the new architecture.
 
-    The 'interface' parameter is kept for downstream compatibility (e.g., EasyDiffraction)
-    but is not actively used within EasyCrystallography itself.
+    Interface Pattern
+    -----------------
+    The 'interface' parameter is a **passthrough for downstream applications**
+    (e.g., EasyDiffraction) and is not actively used within EasyCrystallography itself.
+
+    EasyCrystallography does not have its own calculator implementations. The interface
+    allows downstream applications to:
+
+    - Inject their own calculator/interface that works with these crystallography objects
+    - Call `generate_bindings()` when objects are modified to sync with their calculators
+    - Access the interface via the `interface` property on any model object
+
+    When `interface` is `None` (the default), all binding-related methods are no-ops.
+
+    Example usage in downstream applications::
+
+        # In EasyDiffraction or similar
+        phase = Phase(...)
+        phase.interface = my_diffraction_calculator
+        phase.generate_bindings()  # Syncs with calculator
     """
 
     def __init__(
@@ -42,7 +60,10 @@ class BaseCore(ModelBase):
         Initialize the base core object.
 
         :param name: Display name for the object
-        :param interface: Optional interface for downstream calculator bindings
+        :param interface: Optional interface for downstream calculator bindings.
+            This is a passthrough parameter - EasyCrystallography does not use it
+            internally, but downstream applications (like EasyDiffraction) can set
+            their own calculator interface here.
         :param unique_name: Optional unique identifier
         :param kwargs: Additional keyword arguments (parameters, descriptors, sub-objects)
         """
@@ -102,18 +123,35 @@ class BaseCore(ModelBase):
 
     @property
     def interface(self) -> Optional[InterfaceFactoryTemplate]:
-        """Get the current interface of the object."""
+        """Get the current interface of the object.
+
+        The interface is a passthrough for downstream applications (e.g., EasyDiffraction).
+        EasyCrystallography does not use this internally.
+
+        :return: The current interface, or None if not set.
+        """
         return self._interface
 
     @interface.setter
     def interface(self, new_interface: Optional[InterfaceFactoryTemplate]) -> None:
-        """Set the interface for downstream calculator bindings."""
+        """Set the interface for downstream calculator bindings.
+
+        :param new_interface: The calculator interface from a downstream application,
+            or None to clear the interface.
+        """
         self._interface = new_interface
 
     def generate_bindings(self) -> None:
         """Generate or re-generate bindings to an interface.
 
-        This is kept for downstream compatibility but is a no-op if no interface is set.
+        This method is a passthrough for downstream applications. When called:
+
+        - If interface is None: This is a no-op
+        - If interface is set: Calls interface.generate_bindings(self) to sync
+          the object state with the downstream calculator
+
+        Downstream applications (like EasyDiffraction) should call this after
+        modifying objects to ensure their calculators stay synchronized.
         """
         if self._interface is not None and hasattr(self._interface, 'generate_bindings'):
             self._interface.generate_bindings(self)

--- a/src/easycrystallography/Components/base_core.py
+++ b/src/easycrystallography/Components/base_core.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: 2024 EasyCrystallography contributors
+# SPDX-License-Identifier: BSD-3-Clause
+# © 2022-2024 Contributors to the EasyCrystallography project <https://github.com/EasyScience/EasyCrystallography>
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from easyscience import global_object
+from easyscience.base_classes import ModelBase
+from easyscience.io.serializer_base import SerializerBase
+from easyscience.variable import Parameter
+from easyscience.variable.descriptor_base import DescriptorBase
+
+if TYPE_CHECKING:
+    from easyscience.fitting.calculators import InterfaceFactoryTemplate
+
+
+class BaseCore(ModelBase):
+    """Base class for all EasyCrystallography model objects.
+
+    This class bridges the new ModelBase API with the legacy 'name' patterns
+    used throughout EasyCrystallography. The 'name' property maps to 'display_name' in the
+    new architecture.
+
+    The 'interface' parameter is kept for downstream compatibility (e.g., EasyDiffraction)
+    but is not actively used within EasyCrystallography itself.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        interface: Optional[InterfaceFactoryTemplate] = None,
+        unique_name: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Initialize the base core object.
+
+        :param name: Display name for the object
+        :param interface: Optional interface for downstream calculator bindings
+        :param unique_name: Optional unique identifier
+        :param kwargs: Additional keyword arguments (parameters, descriptors, sub-objects)
+        """
+        if unique_name is None:
+            unique_name = global_object.generate_unique_name(self.__class__.__name__)
+        super().__init__(unique_name=unique_name, display_name=name)
+
+        # Store kwargs for parameter access (compatibility with ObjBase pattern)
+        self._kwargs = kwargs
+        for key, value in kwargs.items():
+            # Register components with the global object map
+            if hasattr(value, 'unique_name'):
+                self._global_object.map.add_edge(self, value)
+                self._global_object.map.reset_type(value, 'created_internal')
+
+        # Interface is kept for downstream compatibility
+        self._interface = interface
+
+    def __getattr__(self, name: str):
+        """Forward attribute access to _kwargs for ObjBase compatibility."""
+        # Check if the name exists in _kwargs (handles both regular and underscore-prefixed kwargs)
+        if '_kwargs' in self.__dict__ and name in self._kwargs:
+            return self._kwargs[name]
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+    def __setattr__(self, name: str, value) -> None:
+        """Handle attribute setting for ObjBase compatibility."""
+        # During initialization, use normal setting
+        if '_kwargs' not in self.__dict__:
+            super().__setattr__(name, value)
+            return
+        # If name is in _kwargs, update the value (for Parameters, set .value)
+        if name in self._kwargs:
+            existing = self._kwargs[name]
+            if isinstance(existing, DescriptorBase) and not isinstance(value, DescriptorBase):
+                existing.value = value
+            else:
+                # Replace the component
+                if hasattr(existing, 'unique_name'):
+                    self._global_object.map.prune_vertex_from_edge(self, existing)
+                self._kwargs[name] = value
+                if hasattr(value, 'unique_name'):
+                    self._global_object.map.add_edge(self, value)
+                    self._global_object.map.reset_type(value, 'created_internal')
+        else:
+            super().__setattr__(name, value)
+
+    @property
+    def name(self) -> str:
+        """Get the name of the object (maps to display_name)."""
+        return self.display_name
+
+    @name.setter
+    def name(self, new_name: str) -> None:
+        """Set the name of the object."""
+        self.display_name = new_name
+
+    @property
+    def interface(self) -> Optional[InterfaceFactoryTemplate]:
+        """Get the current interface of the object."""
+        return self._interface
+
+    @interface.setter
+    def interface(self, new_interface: Optional[InterfaceFactoryTemplate]) -> None:
+        """Set the interface for downstream calculator bindings."""
+        self._interface = new_interface
+
+    def generate_bindings(self) -> None:
+        """Generate or re-generate bindings to an interface.
+
+        This is kept for downstream compatibility but is a no-op if no interface is set.
+        """
+        if self._interface is not None and hasattr(self._interface, 'generate_bindings'):
+            self._interface.generate_bindings(self)
+
+    def _add_component(self, key: str, component) -> None:
+        """Dynamically add a component to the class."""
+        self._kwargs[key] = component
+        self._global_object.map.add_edge(self, component)
+        self._global_object.map.reset_type(component, 'created_internal')
+
+    def _get_linkable_attributes(self) -> List[DescriptorBase]:
+        """Get all objects which can be linked against as a list.
+
+        :return: List of `Descriptor`/`Parameter` objects.
+        """
+        item_list = []
+        for key, item in self._kwargs.items():
+            if hasattr(item, '_get_linkable_attributes'):
+                item_list = [*item_list, *item._get_linkable_attributes()]
+            elif isinstance(item, DescriptorBase):
+                item_list.append(item)
+        return item_list
+
+    def get_parameters(self) -> List[Parameter]:
+        """Get all parameter objects as a list.
+
+        :return: List of `Parameter` objects.
+        """
+        par_list = []
+        for key, item in self._kwargs.items():
+            if hasattr(item, 'get_parameters'):
+                par_list = [*par_list, *item.get_parameters()]
+            elif isinstance(item, Parameter):
+                par_list.append(item)
+        return par_list
+
+    def get_fit_parameters(self) -> List[Parameter]:
+        """Get all objects which can be fitted (and are not fixed) as a list.
+
+        :return: List of `Parameter` objects which can be used in fitting.
+        """
+        fit_list = []
+        for key, item in self._kwargs.items():
+            if hasattr(item, 'get_fit_parameters'):
+                fit_list = [*fit_list, *item.get_fit_parameters()]
+            elif isinstance(item, Parameter):
+                if item.independent and not item.fixed:
+                    fit_list.append(item)
+        return fit_list
+
+    def __repr__(self) -> str:
+        """String representation of the object."""
+        return f'{self.__class__.__name__} `{self.name}`'
+
+    def as_dict(self, skip: Optional[List[str]] = None) -> dict:
+        """Produces a cleaned dict using a custom as_dict method.
+        The resulting dict matches the parameters in __init__.
+
+        :param skip: List of keys to skip, defaults to `None`.
+        :return: Dictionary representation of the object.
+        """
+        if skip is None:
+            skip = []
+
+        # Always skip unique_name for nested Parameters to avoid collisions during from_dict
+        param_skip = list(skip) + ['unique_name'] if 'unique_name' not in skip else list(skip)
+
+        result = {
+            '@module': self.__class__.__module__,
+            '@class': self.__class__.__name__,
+            '@version': None,
+        }
+
+        # Add name if not default
+        if 'name' not in skip:
+            result['name'] = self.name
+
+        # Add unique_name if not default
+        if 'unique_name' not in skip and not self._default_unique_name:
+            result['unique_name'] = self.unique_name
+
+        # Check for _REDIRECT class attribute (used by SpaceGroup and similar classes)
+        redirect = getattr(self.__class__, '_REDIRECT', {})
+
+        # Serialize kwargs - use param_skip for nested objects
+        for key, value in self._kwargs.items():
+            # Strip leading underscore from key for serialization
+            key_name = key.lstrip('_') if key.startswith('_') else key
+            if key_name in skip or key in skip:
+                continue
+
+            # Check if this key has a redirect function
+            if key_name in redirect:
+                result[key_name] = redirect[key_name](self)
+            elif hasattr(value, 'as_dict'):
+                result[key_name] = value.as_dict(skip=param_skip)
+            elif hasattr(value, 'to_dict'):
+                result[key_name] = value.to_dict(skip=param_skip)
+            else:
+                result[key_name] = value
+
+        # Add interface for backwards compatibility (always None in EasyCrystallography)
+        if 'interface' not in skip:
+            result['interface'] = None
+
+        return result
+
+    def to_dict(self, skip: Optional[List[str]] = None) -> dict:
+        """Convert to dictionary for serialization (alias for as_dict).
+
+        This overrides NewBase.to_dict to use our custom serialization.
+
+        :param skip: List of keys to skip, defaults to `None`.
+        :return: Dictionary representation of the object.
+        """
+        return self.as_dict(skip=skip)
+
+    @classmethod
+    def from_dict(cls, obj_dict: Dict[str, Any]) -> 'BaseCore':
+        """
+        Re-create an object from a dictionary.
+
+        :param obj_dict: Dictionary containing the serialized contents.
+        :return: Reformed object.
+        """
+        if not SerializerBase._is_serialized_easyscience_object(obj_dict):
+            raise ValueError('Input must be a dictionary representing an EasyScience object.')
+
+        # Deserialize all values
+        kwargs = {}
+        for key, value in obj_dict.items():
+            if key.startswith('@'):
+                continue
+            if isinstance(value, dict) and SerializerBase._is_serialized_easyscience_object(value):
+                kwargs[key] = SerializerBase._deserialize_value(value)
+            else:
+                kwargs[key] = value
+
+        # Create instance
+        return cls(**kwargs)

--- a/src/easycrystallography/Structures/Phase.py
+++ b/src/easycrystallography/Structures/Phase.py
@@ -12,11 +12,11 @@ from typing import Optional
 from typing import Union
 
 import numpy as np
-from easyscience import ObjBase as BaseObj
-from easyscience.base_classes import CollectionBase
 from easyscience.variable import DescriptorStr
 from easyscience.variable import Parameter
 
+from easycrystallography.Components.base_collection import BaseCollection
+from easycrystallography.Components.base_core import BaseCore
 from easycrystallography.Components.Lattice import Lattice
 from easycrystallography.Components.Lattice import PeriodicLattice
 from easycrystallography.Components.Site import Atoms
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from easyscience.utils.typing import iF
 
 
-class Phase(BaseObj):
+class Phase(BaseCore):
     _SITE_CLASS = Site
     _ATOMS_CLASS = Atoms
 
@@ -64,11 +64,10 @@ class Phase(BaseObj):
         if scale is None:
             scale = Parameter('scale', 1, min=0)
 
-        super(Phase, self).__init__(name, cell=cell, _spacegroup=space_group, atoms=atoms, scale=scale)
+        super(Phase, self).__init__(name, interface=interface, cell=cell, _spacegroup=space_group, atoms=atoms, scale=scale)
         if not enforce_sym:
             self.cell.clear_sym()
         self._enforce_sym = enforce_sym
-        self.interface = interface
 
         self._extent = np.array([1, 1, 1])
         self._centre = np.array([0, 0, 0])
@@ -279,7 +278,7 @@ class Phase(BaseObj):
         return s
 
 
-class Phases(CollectionBase):
+class Phases(BaseCollection):
     _SITE_CLASS = Site
     _ATOM_CLASS = Atoms
     _PHASE_CLASS = Phase
@@ -296,13 +295,12 @@ class Phases(CollectionBase):
         if not isinstance(name, str):
             raise AttributeError('Name should be a string!')
 
-        super(Phases, self).__init__(name, *args, **kwargs)
-        self.interface = interface
+        super(Phases, self).__init__(name, *args, interface=interface, **kwargs)
 
     def __repr__(self) -> str:
         return f'Collection of {len(self)} phases: {self.phase_names}'
 
-    def __getitem__(self, idx: Union[int, slice]) -> Union[Parameter, DescriptorStr, BaseObj, CollectionBase]:
+    def __getitem__(self, idx: Union[int, slice]) -> Union[Parameter, DescriptorStr, BaseCore, BaseCollection]:
         if isinstance(idx, str) and idx in self.phase_names:
             idx = self.phase_names.index(idx)
         return super(Phases, self).__getitem__(idx)

--- a/tests/unit_tests/components/test_SpaceGroup.py
+++ b/tests/unit_tests/components/test_SpaceGroup.py
@@ -219,18 +219,19 @@ def test_SpaceGroup_fromIntNumber_HexTest(sg_int: int, setting: bool):
 def test_SpaceGroup_as_dict():
     sg_p = SpaceGroup.from_int_number(146)
     sg_p_dict = sg_p.as_dict()
-    del sg_p_dict['setting']['unique_name']
-    del sg_p_dict['space_group_HM_name']['unique_name']
-    del sg_p_dict['unique_name']
-    del sg_p_dict['space_group_HM_name']['@class']
-    del sg_p_dict['setting']['@class']
-    del sg_p_dict['space_group_HM_name']['@module']
-    del sg_p_dict['setting']['@module']
-    del sg_p_dict['space_group_HM_name']['@version']
-    del sg_p_dict['setting']['@version']
-    del sg_p_dict['@class']
-    del sg_p_dict['@module']
-    del sg_p_dict['@version']
+    sg_p_dict['setting'].pop('unique_name', None)
+    sg_p_dict['space_group_HM_name'].pop('unique_name', None)
+    sg_p_dict.pop('unique_name', None)
+    sg_p_dict.pop('name', None)
+    sg_p_dict['space_group_HM_name'].pop('@class', None)
+    sg_p_dict['setting'].pop('@class', None)
+    sg_p_dict['space_group_HM_name'].pop('@module', None)
+    sg_p_dict['setting'].pop('@module', None)
+    sg_p_dict['space_group_HM_name'].pop('@version', None)
+    sg_p_dict['setting'].pop('@version', None)
+    sg_p_dict.pop('@class', None)
+    sg_p_dict.pop('@module', None)
+    sg_p_dict.pop('@version', None)
 
     assert sg_p_dict == {
                                    'symmetry_ops':        None,


### PR DESCRIPTION
Migrated EasyCrystallography
from the old corelib architecture (`ObjBase`, `CollectionBase`) to the new
architecture (`ModelBase`, `ModelCollection`, `CalculatorFactoryBase`).



### Current Architecture (Before Migration)

```
ObjBase (corelib - deprecated)
├── Lattice (Components/Lattice.py)
│   └── PeriodicLattice
├── Site (Components/Site.py)
│   └── PeriodicSite
├── AdpBase (Components/AtomicDisplacement.py)
│   ├── Anisotropic
│   ├── Isotropic
│   ├── AnisotropicBij
│   └── IsotropicB
├── AtomicDisplacement (Components/AtomicDisplacement.py)
├── SpaceGroup (Components/SpaceGroup.py)
├── MSPBase (Components/Susceptibility.py)
│   ├── Cani
│   └── Ciso
├── MagneticSusceptibility (Components/Susceptibility.py)
└── Phase (Structures/Phase.py)

CollectionBase (corelib - deprecated)
├── Atoms (Components/Site.py)
│   └── PeriodicAtoms
└── Phases (Structures/Phase.py)

Other Classes (no migration needed):
├── Specie (extends DescriptorStr)
├── Twin (plain Python class)
├── SymmOp (extends SerializerComponent)
├── SymmetryGroup/PointGroup/SpaceGroup (Symmetry groups - abstract/metaclass)
└── IO classes (template, parser, star classes)
```

### Target Architecture (After Migration)

```
ModelBase (corelib - new)
├── BaseCore (new compatibility layer)
│   ├── Lattice
│   │   └── PeriodicLattice
│   ├── Site
│   │   └── PeriodicSite
│   ├── AdpBase
│   │   ├── Anisotropic
│   │   ├── Isotropic
│   │   ├── AnisotropicBij
│   │   └── IsotropicB
│   ├── AtomicDisplacement
│   ├── SpaceGroup
│   ├── MSPBase
│   │   ├── Cani
│   │   └── Ciso
│   ├── MagneticSusceptibility
│   └── Phase

ModelCollection (corelib - new)
├── BaseCollection (new compatibility layer)
│   ├── Atoms
│   │   └── PeriodicAtoms
│   └── Phases
```